### PR TITLE
Replace ElementTree with lxml because it's faster

### DIFF
--- a/SpiffWorkflow/bpmn/parser/BpmnParser.py
+++ b/SpiffWorkflow/bpmn/parser/BpmnParser.py
@@ -32,7 +32,7 @@ from SpiffWorkflow.bpmn.specs.EndEvent import EndEvent
 from SpiffWorkflow.bpmn.parser.ProcessParser import ProcessParser
 from SpiffWorkflow.bpmn.parser.util import *
 from SpiffWorkflow.bpmn.parser.task_parsers import *
-import xml.etree.ElementTree as ET
+import lxml.etree as ET
 
 class BpmnParser(object):
     """

--- a/SpiffWorkflow/bpmn/parser/task_parsers.py
+++ b/SpiffWorkflow/bpmn/parser/task_parsers.py
@@ -18,7 +18,7 @@ from SpiffWorkflow.bpmn.parser.ValidationException import ValidationException
 from SpiffWorkflow.bpmn.parser.TaskParser import TaskParser
 from SpiffWorkflow.bpmn.parser.util import *
 from SpiffWorkflow.bpmn.specs.event_definitions import TimerEventDefinition, MessageEventDefinition
-import xml.etree.ElementTree as ET
+import lxml.etree as ET
 
 class StartEventParser(TaskParser):
     """

--- a/SpiffWorkflow/bpmn/specs/BpmnProcessSpec.py
+++ b/SpiffWorkflow/bpmn/specs/BpmnProcessSpec.py
@@ -18,7 +18,7 @@ from SpiffWorkflow.Task import Task
 from SpiffWorkflow.bpmn.specs.UnstructuredJoin import UnstructuredJoin
 from SpiffWorkflow.specs.Simple import Simple
 from SpiffWorkflow.specs.WorkflowSpec import WorkflowSpec
-import xml.etree.ElementTree as ET
+import lxml.etree as ET
 
 class _EndJoin(UnstructuredJoin):
 

--- a/SpiffWorkflow/bpmn/storage/BpmnSerializer.py
+++ b/SpiffWorkflow/bpmn/storage/BpmnSerializer.py
@@ -15,8 +15,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 import ConfigParser
-from StringIO import StringIO
-import xml.etree.ElementTree as ET
+from cStringIO import StringIO
+import lxml.etree as ET
 import zipfile
 import os
 from SpiffWorkflow.bpmn.parser.BpmnParser import BpmnParser

--- a/SpiffWorkflow/bpmn/storage/Packager.py
+++ b/SpiffWorkflow/bpmn/storage/Packager.py
@@ -15,11 +15,11 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 import ConfigParser
-from StringIO import StringIO
+from cStringIO import StringIO
 import glob
 import hashlib
 import inspect
-import xml.etree.ElementTree as ET
+import lxml.etree as ET
 import zipfile
 from optparse import OptionParser, OptionGroup
 import os

--- a/tests/SpiffWorkflow/run_suite.py
+++ b/tests/SpiffWorkflow/run_suite.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import os, sys, unittest, glob, fnmatch, re
 from inspect import isfunction, ismodule, isclass
 


### PR DESCRIPTION
We replace ElementTree with lxml because it's faster.

*Testing*

So far I've run the unit tests and the same number are passing before and after the patch (2 tests were failing before and after).

I plan to do more testing once I figure out how.

*Branch management*

I've created a new branch `v0.3.0-j5.28.0a` to merge this into. It's based on `v0.3.0-j1.15.0a3` which is the current version used in 28.0. Once this is merged I will create a tag `v0.3.0.j5-28.0a1` which will be referenced in the `requirements.txt` of the j5-framework.