### PR TITLE
Remove exception handling from ScriptTask method. 

### DIFF
--- a/SpiffWorkflow/bpmn/specs/ScriptTask.py
+++ b/SpiffWorkflow/bpmn/specs/ScriptTask.py
@@ -45,15 +45,5 @@ class ScriptTask(Simple, BpmnSpecMixin):
         if task.workflow._is_busy_with_restore():
             return
         assert not task.workflow.read_only
-        try:
-            task.workflow.script_engine.execute(task, self.script, **task.data)
-        except Exception:
-            LOG.error('Error executing ScriptTask; task=%r',
-                      task, exc_info=True)
-            # set state to WAITING (because it is definitely not COMPLETED)
-            # and raise WorkflowException pointing to this task because
-            # maybe upstream someone will be able to handle this situation
-            task._setstate(Task.WAITING, force=True)
-            raise WorkflowTaskExecException(
-                task, 'Error during script execution')
+        task.workflow.script_engine.execute(task, self.script, **task.data)
         super(ScriptTask, self)._on_complete_hook(task)

--- a/SpiffWorkflow/bpmn/specs/ScriptTask.py
+++ b/SpiffWorkflow/bpmn/specs/ScriptTask.py
@@ -45,5 +45,9 @@ class ScriptTask(Simple, BpmnSpecMixin):
         if task.workflow._is_busy_with_restore():
             return
         assert not task.workflow.read_only
+        # We have reverted an upstream change which included try...except
+        # because this prevented XmlFunctionResponse and similar exceptions
+        # being propagated to the j5 user interface, which broke pop up
+        # messages.
         task.workflow.script_engine.execute(task, self.script, **task.data)
         super(ScriptTask, self)._on_complete_hook(task)


### PR DESCRIPTION
Remove exception handling from ScriptTask _on_complete_hook method. The WorkflowTaskExecException and its parent WorkflowException are never actually handled in SpiffWorkflow code, or in j5 code, so there shouldn't be a problem allowing the original exception to be raised instead of catching it and raising a new exception.

j5 code uses XmlFunctionResponse and other ResponseSignal exceptions which are used by the j5 UI, for instance to pop up a confirmation dialog, so it is necessary for these exceptions to be raised and not altered.